### PR TITLE
Warning to run the installation as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Masternode
 3DCoin Masternode auto installer
 
+**Warning: The installation must be run as root user!**
+
 ****************************************
 Automatic install Single 3DCoin masternode
 ****************************************


### PR DESCRIPTION
Add initial warning in the README.md to run the masternode installation as root.