### PR TITLE
change definition of variable $dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -161,7 +161,7 @@ exit;
 else
 killall -9 3dcoind
 rm -f /usr/local/bin/3dcoind
-dir="\\$"\$(find / -type d -name "3dcoin" -print) 
+dir=/root/3dcoin 
 cd "\\$"\$dir
 git pull
 make install || { ./autogen.sh && ./configure --disable-tests --disable-gui-tests --without-gui && make install;  }
@@ -330,7 +330,7 @@ exit;
 else
 killall -9 3dcoind
 rm -f /usr/local/bin/3dcoind
-dir="\\$"\$(find / -type d -name "3dcoin" -print) 
+dir=/root/3dcoin 
 cd "\\$"\$dir
 git pull
 make install || { ./autogen.sh && ./configure --disable-tests --disable-gui-tests --without-gui && make install;  }
@@ -466,7 +466,7 @@ exit;
 else
 killall -9 3dcoind
 rm -f /usr/local/bin/3dcoind
-dir=\$(find / -type d -name "3dcoin" -print) 
+dir=/root/3dcoin 
 cd \$dir
 git pull
 make install || { ./autogen.sh && ./configure --disable-tests --disable-gui-tests --without-gui && make install;  }
@@ -653,7 +653,7 @@ exit;
 else
 killall -9 3dcoind
 rm /usr/local/bin/3dcoind
-dir=$(find / -type d -name "3dcoin" -print) 
+dir=/root/3dcoin 
 cd $dir
 git pull
 make install || { ./autogen.sh && ./configure --disable-tests --disable-gui-tests --without-gui && make install;  }


### PR DESCRIPTION
During set of variable localcontent, we assume file configure.ac is located under /root/3dcoin, why search for this directory after that assumption? In addition to previous assumtion: with ubuntu 18.04, the builtin cd of bash exit with staus 1 "cd: too many arguments" if more than one directory is found. That is our case "https://3dctalk.net/topic/1141/implemented-now-the-function-of-autoupdate-for-masternodes-howto-install-from-official-script/4"